### PR TITLE
feat: add Firebase App Distribution plugin and enable debug mode in d…

### DIFF
--- a/.github/workflows/firebase_distribution.yml
+++ b/.github/workflows/firebase_distribution.yml
@@ -41,3 +41,4 @@ jobs:
           groups: testers
           file: app/build/outputs/apk/debug/app-debug.apk
           releaseNotes: ${{ inputs.release_notes }}
+          debug: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.google.gms.google-services")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.10"
+    id("com.google.firebase.appdistribution") version "5.1.1" apply false
 }
 
 android {


### PR DESCRIPTION
This pull request introduces changes to integrate Firebase App Distribution and enhance debugging capabilities for the app's distribution workflow. The most important changes include adding the Firebase App Distribution plugin to the Gradle build file and enabling debug mode in the Firebase distribution workflow.

Integration of Firebase App Distribution:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R7): Added the Firebase App Distribution plugin (`com.google.firebase.appdistribution`) with version `5.1.1` to the Gradle build file, but marked it as not applied by default.

Enhancement of debugging capabilities:

* [`.github/workflows/firebase_distribution.yml`](diffhunk://#diff-444bd40a4fe3edd84d9fa01f3e85fa4723c34acdb2c632639854cdfdebb64cc2R44): Enabled debug mode in the Firebase distribution workflow by adding the `debug: true` parameter.…istribution configuration